### PR TITLE
Removed uppercase from ModelName AllowedPattern

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -49,7 +49,8 @@ Parameters:
     Description: Name of the model
     MinLength: 1
     MaxLength: 15 # Limited to this due to mlops-{model}-{dev/prd}-{pipeline-executionid}
-    AllowedPattern: ^[a-zA-Z0-9](-*[a-zA-Z0-9])*
+    AllowedPattern: ^[a-z0-9](-*[a-z0-9])* # no UPPERCASE due to S3 naming restrictions
+    ConstraintDescription: Must be lowercase or numbers with a length of 1-15 characters.
   NotebookInstanceType:
     Type: String
     Default: ml.t3.medium


### PR DESCRIPTION
Removed uppercase from ModelName AllowedPattern due to use in S3 name string and S3 naming restrictions.  Added ContraintDescription for it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
