### PR TITLE
Added iam:CreateServiceLinkedRole to mlops-deploy policy

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -670,6 +670,7 @@ Resources:
                   - iam:PutRolePolicy
                   - iam:PassRole
                   - iam:DeleteRolePolicy
+                  - iam:CreateServiceLinkedRole
                   - lambda:InvokeFunction
                 Resource: "*"
               - Sid: SageMakerDeployment


### PR DESCRIPTION

*Issue #, if available:* No issue opened, stack deploy-model-prd fails on deployment as iam:CreateServiceLinkedRole is required to deploy the AutoScaling resource.

*Description of changes:*

Added iam:CreateServiceLinkedRole to mlops-deploy policy on main CF template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
