### PR TITLE
Update notebook to exit loop when output uri available

### DIFF
--- a/notebook/mlops.ipynb
+++ b/notebook/mlops.ipynb
@@ -804,20 +804,23 @@
     "            outputs = dict([(o['OutputKey'], o['OutputValue']) for o in stack['Outputs']])\n",
     "        return stack['StackStatus'], outputs \n",
     "\n",
+    "outputs = None\n",
     "while True:\n",
     "    try:\n",
     "        status, outputs = get_stack_status(stack_name)\n",
-    "        print('stack status: {}'.format(status))\n",
-    "        if status.endswith('COMPLETE') or status.endswith('FAILED'):\n",
+    "        response = sm.describe_endpoint(EndpointName=prd_endpoint_name)\n",
+    "        print(\"Endpoint status: {}\".format(response['EndpointStatus']))\n",
+    "        if outputs:\n",
     "            break\n",
+    "        elif status.endswith('FAILED'):\n",
+    "            raise(Exception('Stack status: {}'.format(status)))\n",
     "    except ClientError as e:\n",
     "        print(e.response[\"Error\"][\"Message\"])\n",
-    "    time.sleep(10)    \n",
-    "                \n",
+    "    time.sleep(10)\n",
     "\n",
     "if outputs:\n",
     "    print('deployment application: {}'.format(outputs['DeploymentApplication']))\n",
-    "    print('rest api: {}'.format(outputs['RestApi']))                "
+    "    print('rest api: {}'.format(outputs['RestApi']))"
    ]
   },
   {
@@ -869,6 +872,8 @@
     "        if status.endswith('COMPLETE'):\n",
     "            print('Deployment complete\\n')\n",
     "            break\n",
+    "        elif status.endswith('FAILED'):\n",
+    "            raise(Exception('Stack status: {}'.format(status)))\n",
     "    except ClientError as e:\n",
     "        print(e.response[\"Error\"][\"Message\"])\n",
     "    time.sleep(10)"


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Update to continue in notebook once the endpoint is available, so that see endpoint transition before stack complete.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
