### PR TITLE
[fix] Replace underscore with dash in SageMaker CodeRepository name given it doesn't support underscore in name

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -132,7 +132,7 @@ Resources:
   SageMakerCodeRepository:
     Type: AWS::SageMaker::CodeRepository
     Properties:
-      CodeRepositoryName: !Ref GitHubRepo
+      CodeRepositoryName: !Join [ "-",  !Split [ "_" , !Ref GitHubRepo ] ]
       GitConfig:
         RepositoryUrl:
           Fn::If:


### PR DESCRIPTION
*Issue #, if available:* 
while using github repo name with "_", it fails to create CFN stack as resource type "AWS::SageMaker::CodeRepository" doesn't support "_".

*Description of changes:*
The code change is to replace "_" with "-" which is compatible with the resource type. There is no impact on code commit repo setup, which is with the same name as the github one. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
